### PR TITLE
[#17] feat/#17_editDashBoard_change dashboard color

### DIFF
--- a/components/ChangeDashBoardName/ChangeDashBoardName.tsx
+++ b/components/ChangeDashBoardName/ChangeDashBoardName.tsx
@@ -22,6 +22,7 @@ const ChangeDashBoardName = () => {
     title: '',
     color: '',
   });
+  const [oldDashBoardName, setOldDashBoardName] = useState('');
   const newDashBoardName = useInputValue();
   const selectColorList = ['#7AC555', '#760DDE', '#FFA500', '#76A5EA', '#E876EA'];
 
@@ -32,7 +33,8 @@ const ChangeDashBoardName = () => {
 
   const handleLoadDashBoard = async dashBoardId => {
     try {
-      const result = await getDashBoardData(dashBoardId);
+      const { title } = await getDashBoardData(dashBoardId);
+      setOldDashBoardName(title);
     } catch (error: any) {
       console.error(error);
     }
@@ -61,7 +63,7 @@ const ChangeDashBoardName = () => {
       role='table-Container'
       className='flex flex-col rounded-md bg-tp-white px-7 pt-8 pb-7 shadow-sm w-[38.75rem] gap-8'>
       <div role='header' className='flex justify-between'>
-        <h1 className='text-[1.25rem] font-bold text-tp-black_700'>{mockData.title}</h1>
+        <h1 className='text-[1.25rem] font-bold text-tp-black_700'>{oldDashBoardName}</h1>
         <div className='flex items-center gap-2.5'>
           {selectColorList.map(color => {
             return (
@@ -89,8 +91,8 @@ const ChangeDashBoardName = () => {
         <input
           id='change-dashboard-title'
           type='text'
-          className='p-4 w-[35.25rem] rounded-md border border-solid border-tp-gray_700'
-          placeholder={mockData.title}
+          className='p-4 w-[35.25rem] rounded-md border border-solid border-tp-gray_700 outline-tp-violet_900'
+          placeholder={oldDashBoardName}
           onChange={newDashBoardName.onChange}
           value={newDashBoardName.inputValue}
         />
@@ -101,7 +103,6 @@ const ChangeDashBoardName = () => {
         className='py-1.5 px-7 rounded-md bg-tp-violet_900 self-end text-white'>
         변경
       </button>
-      {/** 버튼 컴포넌트로 변경 예정 */}
     </form>
   );
 };

--- a/components/ChangeDashBoardName/ChangeDashBoardName.tsx
+++ b/components/ChangeDashBoardName/ChangeDashBoardName.tsx
@@ -1,18 +1,9 @@
 'use client';
+import { useInputValue } from '@/hooks/useInputValue';
+import { changeDashBoard } from '@/utils/api/changeDashBoard';
+import { getDashBoardData } from '@/utils/api/getDashBoardData';
 import Image from 'next/image';
-import { MouseEvent, useEffect, useState } from 'react';
-
-interface DataForm {
-  data: {
-    id: number;
-    title: string;
-    color: string;
-    createdAt: string;
-    updatedAt: string;
-    userId: number;
-    createdByMe: boolean;
-  };
-}
+import { FormEvent, MouseEvent, useEffect, useState } from 'react';
 
 const mockData = {
   id: 5946,
@@ -27,6 +18,11 @@ const mockData = {
 
 const ChangeDashBoardName = () => {
   const [selectColor, setSelectColor] = useState('#7AC555');
+  const [changeDashBoardData, setChangeDashBoardData] = useState({
+    title: '',
+    color: '',
+  });
+  const newDashBoardName = useInputValue();
   const selectColorList = ['#7AC555', '#760DDE', '#FFA500', '#76A5EA', '#E876EA'];
 
   const handleSelectColor = (event: MouseEvent<HTMLButtonElement>) => {
@@ -34,8 +30,34 @@ const ChangeDashBoardName = () => {
     setSelectColor(event.currentTarget.id);
   };
 
+  const handleLoadDashBoard = async dashBoardId => {
+    try {
+      const result = await getDashBoardData(dashBoardId);
+    } catch (error: any) {
+      console.error(error);
+    }
+  };
+
+  const handleChangeDashBoard = async (event: FormEvent<HTMLElement>) => {
+    event.preventDefault();
+    setChangeDashBoardData({
+      title: newDashBoardName.inputValue,
+      color: selectColor,
+    });
+    try {
+      const result = changeDashBoard({ dashBoardId: 5946, changeData: changeDashBoardData });
+    } catch (error: any) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    handleLoadDashBoard(5946);
+  }, []);
+
   return (
     <form
+      onSubmit={handleChangeDashBoard}
       role='table-Container'
       className='flex flex-col rounded-md bg-tp-white px-7 pt-8 pb-7 shadow-sm w-[38.75rem] gap-8'>
       <div role='header' className='flex justify-between'>
@@ -69,9 +91,14 @@ const ChangeDashBoardName = () => {
           type='text'
           className='p-4 w-[35.25rem] rounded-md border border-solid border-tp-gray_700'
           placeholder={mockData.title}
+          onChange={newDashBoardName.onChange}
+          value={newDashBoardName.inputValue}
         />
       </div>
-      <button type='submit' className='py-1.5 px-7 rounded-md bg-tp-violet_900 self-end text-white'>
+      <button
+        type='submit'
+        onSubmit={handleChangeDashBoard}
+        className='py-1.5 px-7 rounded-md bg-tp-violet_900 self-end text-white'>
         변경
       </button>
       {/** 버튼 컴포넌트로 변경 예정 */}

--- a/components/Modal/WorkModal/CreateWorkModal.tsx
+++ b/components/Modal/WorkModal/CreateWorkModal.tsx
@@ -1,11 +1,8 @@
 import { ChangeEvent, useState } from 'react';
-import InputImageButton from '../Button/InputImageButton';
-import ModalDropdown from '../Input/ModalDropdown';
 import ModalLayout from '../ModalLayout';
 import PersonInChargeDropDown from './components/PersonInChargeDropDown';
 import ProgressDropDown from './components/ProgressDropDown';
-import Image from 'next/image';
-import InputImageFile from '@components/InputImage/InputImage';
+import InputImageFile from '@/components/InputImage/InputImage';
 
 const CreateWorkModal = ({ handleModal }: { handleModal: () => void }) => {
   const [selectImage, setSelectImage] = useState('');

--- a/components/Modal/WorkModal/components/PersonInChargeDropDown.tsx
+++ b/components/Modal/WorkModal/components/PersonInChargeDropDown.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DEFAULT_PROFILE_IMAGE } from '@components/Table/constant';
+import { DEFAULT_PROFILE_IMAGE } from '@/components/Table/constant';
 import Image from 'next/image';
 import { MouseEvent, useState } from 'react';
 

--- a/utils/api/changeDashBoard.ts
+++ b/utils/api/changeDashBoard.ts
@@ -1,0 +1,23 @@
+import { ACCESS_TOKEN } from '../temporaryToken';
+
+interface ChangeDashBoardData {
+  dashBoardId: number;
+  changeData: {
+    title: string;
+    color: string;
+  };
+}
+
+export const changeDashBoard = async ({ dashBoardId, changeData }: ChangeDashBoardData) => {
+  const response = await fetch(`https://sp-taskify-api.vercel.app/14/dashboards/${dashBoardId}`, {
+    method: 'PUT',
+    body: JSON.stringify(changeData),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: ACCESS_TOKEN,
+    },
+  });
+
+  const result = response.json();
+  return result;
+};

--- a/utils/api/getDashBoardData.ts
+++ b/utils/api/getDashBoardData.ts
@@ -1,0 +1,13 @@
+import { ACCESS_TOKEN } from '../temporaryToken';
+
+export const getDashBoardData = async dashBoardId => {
+  const response = await fetch(`https://sp-taskify-api.vercel.app/14/dashboards/${dashBoardId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: ACCESS_TOKEN,
+    },
+  });
+
+  const result = response.json();
+  return result;
+};


### PR DESCRIPTION
## 작성자
- [ ] 한태욱
- [ ] 김규헌
- [x] 김유경

## Issue Number
#17

## PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ScreenShot
![대쉬보드](https://github.com/Sprint-Part3-Team14/Taskify/assets/153581513/ea00224e-41c5-4ca9-ac22-eb7e63ec8d2f)


### Commit description
76ccede575c25e098e28b2d99ebc2042f7cae5b9 : import 경로 에러 수정
[48abfb8](https://github.com/Sprint-Part3-Team14/Taskify/pull/30/commits/48abfb8a12ff6a795a7f34c0284519f0ef19f775) : 대쉬보드 명 및 색상 변경 기능 추가
[0e76140](https://github.com/Sprint-Part3-Team14/Taskify/pull/30/commits/0e76140bc0a996881a2af122b7b69877b6e74cdd) : 대쉬보드 정보에 따라서 타이틀 및 placeholder이 변경되도록 함