### PR TITLE
[#6] Refactor/#6_page nation button disabled UI

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -16,9 +16,6 @@ const DashboardLayoutProfile = ({ children }: PropsWithChildren) => {
   const path = usePathname();
   const dashboardId = path.split('/')[2];
 
-  console.log('어렵네')
-  console.log(dashboardInfo);
-
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
@@ -32,7 +29,6 @@ const DashboardLayoutProfile = ({ children }: PropsWithChildren) => {
         });
         if (response.ok) {
           const data = await response.json();
-          console.log(data);
           setDashboardInfo(data);
         } else {
           throw new Error('Failed to fetch dashboard details');

--- a/components/Modal/InviteModal.tsx
+++ b/components/Modal/InviteModal.tsx
@@ -1,27 +1,37 @@
-
-
-import Toast from '../common/Toast/Toast';
-
+import { MouseEvent } from 'react';
 import ModalButton from './Button/ModalButton';
 import ModalLayout from './ModalLayout';
 import { I_ModalToggle } from './ModalType';
 
 import { useInputValue } from '@/hooks/useInputValue';
-import { useHandleToast } from '@/hooks/usehandleToast';
 import { postInvitation } from '@/utils/api/postInvitation';
 
-const InviteModal = ({ handleModal, dashboardId, dataHandler }: I_ModalToggle) => {
-  const { inputValue, onChange } = useInputValue();
-  const { isShowToast, handleToggleToast, setIsShowToast, type, handleToastType, message, handleToastMessage } =
-    useHandleToast();
+interface I_InviteModalProps extends I_ModalToggle {
+  handleToggleToast: () => void;
+  handleToastMessage: (string) => void;
+  handleToastType: (I_ToastType) => void;
+}
 
-  const handlePostInvitation = async () => {
+type I_ToastType = 'complete' | 'error';
+
+const InviteModal = ({
+  handleModal,
+  dashboardId,
+  dataHandler,
+  handleToggleToast,
+  handleToastMessage,
+  handleToastType,
+}: I_InviteModalProps) => {
+  const { inputValue, onChange } = useInputValue();
+
+  const handlePostInvitation = async (event: MouseEvent<HTMLButtonElement>) => {
     try {
       await postInvitation({ email: inputValue, dashboardId: dashboardId });
       handleToggleToast();
       handleToastMessage('초대가 완료되었습니다.');
       handleToastType('complete');
       dataHandler();
+      handleModal(event);
     } catch (error: any) {
       handleToggleToast();
       handleToastMessage(error.message);
@@ -31,15 +41,6 @@ const InviteModal = ({ handleModal, dashboardId, dataHandler }: I_ModalToggle) =
 
   return (
     <>
-      {isShowToast && (
-        <Toast
-          type={type}
-          message={message}
-          handleToast={handleToggleToast}
-          setShowToast={setIsShowToast}
-          isToast={isShowToast}
-        />
-      )}
       <ModalLayout handleModal={handleModal} title='초대하기'>
         <form className='flex flex-col gap-1.5 '>
           <label className='mb-2.5'>이메일</label>

--- a/components/Modal/InviteModal.tsx
+++ b/components/Modal/InviteModal.tsx
@@ -1,4 +1,7 @@
 import { MouseEvent } from 'react';
+
+import Toast from '../common/Toast/Toast';
+
 import ModalButton from './Button/ModalButton';
 import ModalLayout from './ModalLayout';
 import { I_ModalToggle } from './ModalType';
@@ -6,8 +9,6 @@ import { I_ModalToggle } from './ModalType';
 import { useInputValue } from '@/hooks/useInputValue';
 import { useHandleToast } from '@/hooks/usehandleToast';
 import { postInvitation } from '@/utils/api/postInvitation';
-
-import Toast from '../common/Toast/Toast';
 
 interface I_InviteModalProps extends I_ModalToggle {
   isShowModal: boolean;

--- a/components/Modal/InviteModal.tsx
+++ b/components/Modal/InviteModal.tsx
@@ -4,25 +4,19 @@ import ModalLayout from './ModalLayout';
 import { I_ModalToggle } from './ModalType';
 
 import { useInputValue } from '@/hooks/useInputValue';
+import { useHandleToast } from '@/hooks/usehandleToast';
 import { postInvitation } from '@/utils/api/postInvitation';
 
+import Toast from '../common/Toast/Toast';
+
 interface I_InviteModalProps extends I_ModalToggle {
-  handleToggleToast: () => void;
-  handleToastMessage: (string) => void;
-  handleToastType: (I_ToastType) => void;
+  isShowModal: boolean;
 }
 
-type I_ToastType = 'complete' | 'error';
-
-const InviteModal = ({
-  handleModal,
-  dashboardId,
-  dataHandler,
-  handleToggleToast,
-  handleToastMessage,
-  handleToastType,
-}: I_InviteModalProps) => {
+const InviteModal = ({ handleModal, dashboardId, dataHandler, isShowModal }: I_InviteModalProps) => {
   const { inputValue, onChange } = useInputValue();
+  const { isShowToast, type, message, handleToggleToast, setIsShowToast, handleToastMessage, handleToastType } =
+    useHandleToast();
 
   const handlePostInvitation = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -42,24 +36,35 @@ const InviteModal = ({
 
   return (
     <>
-      <ModalLayout handleModal={handleModal} title='초대하기'>
-        <form className='flex flex-col gap-1.5 '>
-          <label className='mb-2.5'>이메일</label>
-          <input
-            onChange={onChange}
-            className='p-4 border border-solid border-tp-gray_700 rounded-lg mb-7 w-[30.0rem] outline-tp-violet_900'
-            type='text'
-            placeholder='이메일을 입력해 주세요'
-          />
-          <ModalButton
-            buttonType='double'
-            firstButton='취소'
-            secondButton='초대'
-            onClickFirstButton={handleModal}
-            onClickSecondButton={handlePostInvitation}
-          />
-        </form>
-      </ModalLayout>
+      {isShowToast && (
+        <Toast
+          type={type}
+          message={message}
+          handleToast={handleToggleToast}
+          setShowToast={setIsShowToast}
+          isToast={isShowToast}
+        />
+      )}
+      {isShowModal && (
+        <ModalLayout handleModal={handleModal} title='초대하기'>
+          <form className='flex flex-col gap-1.5 '>
+            <label className='mb-2.5'>이메일</label>
+            <input
+              onChange={onChange}
+              className='p-4 border border-solid border-tp-gray_700 rounded-lg mb-7 w-[30.0rem] outline-tp-violet_900'
+              type='text'
+              placeholder='이메일을 입력해 주세요'
+            />
+            <ModalButton
+              buttonType='double'
+              firstButton='취소'
+              secondButton='초대'
+              onClickFirstButton={handleModal}
+              onClickSecondButton={handlePostInvitation}
+            />
+          </form>
+        </ModalLayout>
+      )}
     </>
   );
 };

--- a/components/Modal/InviteModal.tsx
+++ b/components/Modal/InviteModal.tsx
@@ -25,6 +25,7 @@ const InviteModal = ({
   const { inputValue, onChange } = useInputValue();
 
   const handlePostInvitation = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
     try {
       await postInvitation({ email: inputValue, dashboardId: dashboardId });
       handleToggleToast();

--- a/components/PageNation/PageNationButton.tsx
+++ b/components/PageNation/PageNationButton.tsx
@@ -39,7 +39,7 @@ const PageNationButton = ({
   }, [currentPage]);
   return (
     <div className='flex items-center pc:gap-4 mb:gap-2.5 '>
-      {hiddenCount && (
+      {!hiddenCount && (
         <p className='text-sm text-tp-black_700'>
           {totalPage} 페이지 중 {currentPage}
         </p>

--- a/components/PageNation/PageNationButton.tsx
+++ b/components/PageNation/PageNationButton.tsx
@@ -39,7 +39,7 @@ const PageNationButton = ({
   }, [currentPage]);
   return (
     <div className='flex items-center pc:gap-4 mb:gap-2.5 '>
-      {!hiddenCount && (
+      {hiddenCount && (
         <p className='text-sm text-tp-black_700'>
           {totalPage} 페이지 중 {currentPage}
         </p>
@@ -50,7 +50,7 @@ const PageNationButton = ({
           onClick={handleCurrentPage}
           type='button'
           className={`border border-solid border-tp-gray_700 rounded-l-md pc:p-3 mb:p-2.5 ${hasPrevious ? '' : 'active:bg-tp-gray_600'}`}>
-          <div className={`w-4 h-4 relative ${hasPrevious && 'opacity-30'}`}>
+          <div className={`w-4 h-4 relative ${hasPrevious ? 'opacity-30' : ''}`}>
             <Image fill src={ArrowForwardIcon} alt='다음 페이지 보기' />
           </div>
         </button>
@@ -59,7 +59,7 @@ const PageNationButton = ({
           onClick={handleCurrentPage}
           type='button'
           className={`border border-solid border-tp-gray_700 rounded-r-md pc:p-3 mb:p-2.5 ${hasNext ? '' : 'active:bg-tp-gray_600'}`}>
-          <div className={`w-4 h-4 relative  ${hasNext && 'opacity-30'}`}>
+          <div className={`w-4 h-4 relative  ${hasNext ? 'opacity-30' : ''}`}>
             <Image fill src={ArrowBackwardIcon} alt='다음 페이지 보기' />
           </div>
         </button>

--- a/components/PageNation/PageNationButton.tsx
+++ b/components/PageNation/PageNationButton.tsx
@@ -1,6 +1,6 @@
 import { ArrowBackwardIcon, ArrowForwardIcon } from 'constant/importImage';
 import Image from 'next/image';
-import { MouseEvent } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 
 interface PageNationButtonProps {
   currentPage: number;
@@ -15,6 +15,28 @@ const PageNationButton = ({
   handleCurrentPage,
   hiddenCount = false,
 }: PageNationButtonProps) => {
+  const [hasPrevious, setHasPrevious] = useState(false);
+  const [hasNext, setNext] = useState(false);
+  const hasNextPage = () => {
+    if (currentPage === totalPage) {
+      setNext(true);
+    } else {
+      setNext(false);
+    }
+  };
+
+  const hasPreviousPage = () => {
+    if (currentPage === 1) {
+      setHasPrevious(true);
+    } else {
+      setHasPrevious(false);
+    }
+  };
+
+  useEffect(() => {
+    hasNextPage();
+    hasPreviousPage();
+  }, [currentPage]);
   return (
     <div className='flex items-center pc:gap-4 mb:gap-2.5 '>
       {!hiddenCount && (
@@ -27,8 +49,8 @@ const PageNationButton = ({
           id='previous'
           onClick={handleCurrentPage}
           type='button'
-          className='border border-solid border-tp-gray_700 rounded-l-md active:bg-tp-gray_600 pc:p-3 mb:p-2.5'>
-          <div className='w-4 h-4 relative'>
+          className={`border border-solid border-tp-gray_700 rounded-l-md pc:p-3 mb:p-2.5 ${hasPrevious ? '' : 'active:bg-tp-gray_600'}`}>
+          <div className={`w-4 h-4 relative ${hasPrevious && 'opacity-30'}`}>
             <Image fill src={ArrowForwardIcon} alt='다음 페이지 보기' />
           </div>
         </button>
@@ -36,8 +58,8 @@ const PageNationButton = ({
           id='next'
           onClick={handleCurrentPage}
           type='button'
-          className='border border-solid border-tp-gray_700 rounded-r-md active:bg-tp-gray_600 pc:p-3 mb:p-2.5'>
-          <div className='w-4 h-4 relative'>
+          className={`border border-solid border-tp-gray_700 rounded-r-md pc:p-3 mb:p-2.5 ${hasNext ? '' : 'active:bg-tp-gray_600'}`}>
+          <div className={`w-4 h-4 relative  ${hasNext && 'opacity-30'}`}>
             <Image fill src={ArrowBackwardIcon} alt='다음 페이지 보기' />
           </div>
         </button>

--- a/components/Table/InvitationHistory.tsx
+++ b/components/Table/InvitationHistory.tsx
@@ -17,22 +17,22 @@ const InvitationHistory = ({ dashboardId }: { dashboardId: number }) => {
   const { isShowModal, handleToggleModal } = useHandleModal();
   const { pageNation, setPageNation, handleCurrentPage } = usePageNation();
   const [invitations, setInvitations] = useState(null);
-  const { isShowToast, handleToggleToast, setIsShowToast, type, handleToastType, message, handleToastMessage } =
-    useHandleToast();
+  const cancelInvite = useHandleToast();
+  const postInvitation = useHandleToast();
   const showCount = 5;
 
   const handleDeleteInvitation = async (event: MouseEvent<HTMLButtonElement>) => {
     const invitationId = Number(event.currentTarget.id);
     try {
       await deletePostInvitation({ dashboardId: dashboardId, invitationId: invitationId });
-      handleToggleToast();
-      handleToastMessage('대시보드 초대가 취소되었습니다.');
-      handleToastType('complete');
+      cancelInvite.handleToggleToast();
+      cancelInvite.handleToastMessage('대시보드 초대가 취소되었습니다.');
+      cancelInvite.handleToastType('complete');
       handleLoadInvitations();
     } catch (error: any) {
-      handleToggleToast();
-      handleToastMessage(error.message);
-      handleToastType('error');
+      cancelInvite.handleToggleToast();
+      cancelInvite.handleToastMessage(error.message);
+      cancelInvite.handleToastType('error');
     }
   };
 
@@ -97,17 +97,33 @@ const InvitationHistory = ({ dashboardId }: { dashboardId: number }) => {
 
   return (
     <>
-      {isShowToast && (
+      {postInvitation.isShowToast && (
         <Toast
-          type={type}
-          message={message}
-          isToast={isShowToast}
-          setShowToast={setIsShowToast}
-          handleToast={handleToggleToast}
+          type={postInvitation.type}
+          message={postInvitation.message}
+          handleToast={postInvitation.handleToggleToast}
+          setShowToast={postInvitation.setIsShowToast}
+          isToast={postInvitation.isShowToast}
+        />
+      )}
+      {cancelInvite.isShowToast && (
+        <Toast
+          type={cancelInvite.type}
+          message={cancelInvite.message}
+          isToast={cancelInvite.isShowToast}
+          setShowToast={cancelInvite.setIsShowToast}
+          handleToast={cancelInvite.handleToggleToast}
         />
       )}
       {isShowModal && (
-        <InviteModal dashboardId={dashboardId} handleModal={handleToggleModal} dataHandler={handleLoadInvitations} />
+        <InviteModal
+          handleToggleToast={postInvitation.handleToggleToast}
+          handleToastMessage={postInvitation.handleToastMessage}
+          handleToastType={postInvitation.handleToastType}
+          dashboardId={dashboardId}
+          handleModal={handleToggleModal}
+          dataHandler={handleLoadInvitations}
+        />
       )}
       <TableLayout title='초대 내역' headerContent={invitationHeader} tableContent={InvitationList} />
     </>

--- a/components/Table/InvitationHistory.tsx
+++ b/components/Table/InvitationHistory.tsx
@@ -18,7 +18,6 @@ const InvitationHistory = ({ dashboardId }: { dashboardId: number }) => {
   const { pageNation, setPageNation, handleCurrentPage } = usePageNation();
   const [invitations, setInvitations] = useState(null);
   const cancelInvite = useHandleToast();
-  const postInvitation = useHandleToast();
   const showCount = 5;
 
   const handleDeleteInvitation = async (event: MouseEvent<HTMLButtonElement>) => {
@@ -97,15 +96,6 @@ const InvitationHistory = ({ dashboardId }: { dashboardId: number }) => {
 
   return (
     <>
-      {postInvitation.isShowToast && (
-        <Toast
-          type={postInvitation.type}
-          message={postInvitation.message}
-          handleToast={postInvitation.handleToggleToast}
-          setShowToast={postInvitation.setIsShowToast}
-          isToast={postInvitation.isShowToast}
-        />
-      )}
       {cancelInvite.isShowToast && (
         <Toast
           type={cancelInvite.type}
@@ -115,16 +105,12 @@ const InvitationHistory = ({ dashboardId }: { dashboardId: number }) => {
           handleToast={cancelInvite.handleToggleToast}
         />
       )}
-      {isShowModal && (
-        <InviteModal
-          handleToggleToast={postInvitation.handleToggleToast}
-          handleToastMessage={postInvitation.handleToastMessage}
-          handleToastType={postInvitation.handleToastType}
-          dashboardId={dashboardId}
-          handleModal={handleToggleModal}
-          dataHandler={handleLoadInvitations}
-        />
-      )}
+      <InviteModal
+        dashboardId={dashboardId}
+        handleModal={handleToggleModal}
+        dataHandler={handleLoadInvitations}
+        isShowModal={isShowModal}
+      />
       <TableLayout title='초대 내역' headerContent={invitationHeader} tableContent={InvitationList} />
     </>
   );

--- a/components/dashboard/LayoutComponents/Buttons.tsx
+++ b/components/dashboard/LayoutComponents/Buttons.tsx
@@ -1,11 +1,11 @@
 import { PlusBlueIcon, SettingIcon } from 'constant/importImage';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useState } from 'react';
 
 import { MembersProps } from './members';
 
 import InviteModal from '@/components/Modal/InviteModal';
+import { useHandleModal } from '@/hooks/useHandleModal';
 
 interface DashboardInfoProps {
   createdByMe?: boolean;
@@ -35,28 +35,20 @@ interface InvitationButtonProps {
   dashboardId: number;
 }
 export const InvitationButton = ({ dashboardId }: InvitationButtonProps) => {
-  const [showModal, setShowModal] = useState(false);
-
-  const toggleModal = () => setShowModal(!showModal);
+  const { isShowModal, handleToggleModal } = useHandleModal();
 
   return (
     <>
       <button
         className='flex justify-center items-center border w-[109px] border-gray-400 rounded-lg'
-        onClick={toggleModal}
-      >
+        onClick={handleToggleModal}>
         <div className='hidden pr-2 tb:block'>
           <Image src={PlusBlueIcon} alt='더하기 버튼' />
         </div>
         초대하기
       </button>
 
-      {showModal && (
-        <InviteModal
-          handleModal={toggleModal}
-          dashboardId={dashboardId}
-        />
-      )}
+      <InviteModal isShowModal={isShowModal} handleModal={handleToggleModal} dashboardId={dashboardId} />
     </>
   );
 };


### PR DESCRIPTION
## 작성자
- [ ] 한태욱
- [ ] 김규헌
- [x] 김유경

## Issue Number
#6

## PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 
![페이지네이션 qlghkftjdghk](https://github.com/Sprint-Part3-Team14/Taskify/assets/153581513/fba8e164-ce14-4f36-9bdb-9de32352cc7c)
![초대하기 모달 초대한 다음에 꺼지게 하기](https://github.com/Sprint-Part3-Team14/Taskify/assets/153581513/06e00fdc-b215-422d-82ee-7bd0783bf2bf)


### Commit description
77958bcc66c53b27a6fead86ac4c4b30f95d9c83 : 이전 페이지나 이후 페이지가 없을 경우 disabled 되도록 함
caa42aeb93f6ada868eefb5ce06d9fe08f9bbb80 : headerLayout에 있던 불필요한 console.log 삭제
23317bb0077da9049b4c34542b113469395c83a4 : 초대하기 모달에서 초대한 뒤에 모달이 닫히도록 수정
eef8ae74efe9f2bd720e2a5cfe27d1348e930dd9 : 초대하기 모달을 킨 상태에서 엔터를 눌렀을 때 리다이렉트되던 문제 해결
e5d7265ee4864bf130d8d205e76dbb6e94be07d5 : 초대하기 관련 모달 및 토스트를 한 파일에서 관리하는 것이 맞다고 판단하여 구조 변경
128edf1406e68b207f887549f32c046cdf7b12e8 : 빌드 에러 해결
37c163e : 확인을 위해 바꿔둔 hidden 조건 수정